### PR TITLE
Add Proof-of-Antiquity (PoA) consensus mechanism

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -127,6 +127,10 @@ _Please check the [contribution guidelines](contributing.md) for info on formatt
 1.  [dBFT vs PoW and PoS](https://www.econotimes.com/Blockchain-project-Antshares-explains-reasons-for-choosing-dBFT-over-PoW-and-PoS-659275) Antshare's (now NEO) views on consensus
 1.  [Intro to Ethermint BFT](https://blog.cosmos.network/a-beginners-guide-to-ethermint-38ee15f8a6f4)
 
+
+#### PoA - Proof of Antiquity
+1.  [RustChain: Proof-of-Antiquity Consensus](https://github.com/Scottcjn/Rustchain) A novel consensus mechanism where mining rewards are weighted by hardware antiquity — vintage devices (PowerPC G4/G5, Pentium 4) earn higher multipliers verified through 6-point hardware fingerprinting. Uses time-aged decay functions, round-robin 1-CPU-1-Vote, and Ergo blockchain anchoring.
+
 ### Network Effects
 1.  [A Note on Metcalfe's Law, Externalities and Ecosystem Splits](https://vitalik.ca/general/2017/07/27/metcalfe.html) by Vitalik Buterin
 1.  [Continuous Token Models: Towards a Million Networks of Value](https://media.consensys.net/exploring-continuous-token-models-towards-a-million-networks-of-value-fff153175776) by Simon de la Rouviere


### PR DESCRIPTION
## Summary

Adds a new "Proof of Antiquity" subsection under Consensus Mechanisms, referencing [RustChain](https://github.com/Scottcjn/Rustchain) as a novel consensus implementation.

**Why it belongs here:**

Proof-of-Antiquity introduces several cryptoeconomic innovations relevant to this list:

1. **Novel consensus mechanism**: Mining rewards are weighted by verified hardware age -- vintage devices earn higher multipliers (e.g., PowerPC G4 = 2.5x, G5 = 2.0x, Pentium 4 = 1.5x) through a time-aged decay function
2. **Hardware attestation game theory**: 6-point fingerprinting (clock drift, cache timing, SIMD identity, thermal drift, instruction jitter, anti-emulation) creates a verification game where spoofing is computationally expensive
3. **Time-aged decay economics**: Antiquity multipliers decay over time using `aged = 1.0 + (base - 1.0) * (1 - 0.15 * chain_age_years)`, creating diminishing returns that incentivize early participation
4. **1-CPU-1-Vote with weighted rewards**: Round-robin consensus ensures equal block production rights while reward distribution reflects hardware authenticity
5. **Cross-chain anchoring**: Attestation commitments are anchored to the Ergo blockchain, providing external verification

Placed as a new subsection alongside PoW, PoS, DPoS, and dBFT, following the numbered list format used throughout the document.